### PR TITLE
Correct spelling of .gitignore in lp.md and lp8.md

### DIFF
--- a/lp.md
+++ b/lp.md
@@ -17,7 +17,7 @@ Note that this is version 0.7 branch. It introduces a variety of changes, but it
 * [TODO.md](#todo "save: | clean raw") A list of growing and shrinking items todo.
 * [LICENSE](#license-mit "save: | clean raw") The MIT license as I think that is the standard in the node community. 
 * [.npmignore](#npmignore "save: ")
-* [.gitgnore](#gitignore "save: ")
+* [.gitignore](#gitignore "save: ")
 * [.travis.yml](#travis "save: ")
 
 

--- a/lp8.md
+++ b/lp8.md
@@ -17,7 +17,7 @@ Note that this is version 0.7 branch. It introduces a variety of changes, but it
 * [TODO.md](#todo "save: | clean raw") A list of growing and shrinking items todo.
 * [LICENSE](#license-mit "save: | clean raw") The MIT license as I think that is the standard in the node community. 
 * [.npmignore](#npmignore "save: ")
-* [.gitgnore](#gitignore "save: ")
+* [.gitignore](#gitignore "save: ")
 * [.travis.yml](#travis "save: ")
 
 


### PR DESCRIPTION
My train has WiFi, so I figured I'd correct the issue I mentioned in jostylr/literate-programming#4
