### PR TITLE
fix requested node engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "main": "lib/literate-programming.js",
   "engines": {
-    "node": ">0.10"
+    "node": ">=0.10"
   },
   "dependencies":{
     "literate-programming-standard": "^0.2.5",


### PR DESCRIPTION
Using  `npm install literate-programming` causes a warning to appear 
literate-programming
`npm WARN engine literate-programming@0.8.1: wanted: {"node":">0.10"} (current: {"node":"0.10.30","npm":"1.4.21"})`

This pull-request fixes the `engines` parameter in the `package.json` file to suppress this warning.
